### PR TITLE
special character password fails

### DIFF
--- a/lib/Credentials/PasswordCredential.js
+++ b/lib/Credentials/PasswordCredential.js
@@ -18,7 +18,7 @@ var PasswordCredential = dejavu.Class.declare({
 
 		this.__hashBuffer = crypto
 			.createHash('sha256')
-			.update(rawPassword, 'binary')
+			.update(new Buffer(rawPassword, 'utf-8'))
 			.digest();
 	},
 

--- a/test/002_password_credential.js
+++ b/test/002_password_credential.js
@@ -6,8 +6,8 @@ var kpio = require('../lib');
 describe('Instantiating a PasswordCredential', function()  {
 	it('should throw a KpioArgumentError when providing no password', function() {
 		(function() {
-			new kpio.Credentials.Password();	
-		}).should.throw(kpio.Errors.Argument);	
+			new kpio.Credentials.Password();
+		}).should.throw(kpio.Errors.Argument);
 	});
 
 	it('should throw a KpioArgumentError when providing an invalid type', function() {
@@ -31,4 +31,20 @@ describe('Instantiating a PasswordCredential', function()  {
 			hash.should.equal('ebdaa59b9b8b28d10847d04c7159a145');
 		});
 	});
+
+    describe('by providing the password `ü`', function () {
+		var credential = null;
+
+		it('should not throw any errors', function() {
+			(function() {
+				credential = new kpio.Credentials.Password('ü');
+			}).should.not.throw();
+		});
+
+		it('#getHash() should match MD5 hash `ebdaa59b9b8b28d10847d04c7159a145`', function() {
+			var hash = credential.getHash();
+			hash = crypto.createHash('md5').update(hash).digest('hex');
+			hash.should.equal('c6afd37d6a9308af8709cf0d250b888e');
+		});
+    });
 });


### PR DESCRIPTION
I had a [bug report](https://github.com/gustavnikolaj/keepass-dmenu/issues/8) in my project [keepass-dmenu](https://github.com/gustavnikolaj/keepass-dmenu/) which uses your library. The bug was that it could not decrypt databases when the password had special characters in it. In this case it was the character `ü` which is common in the german language at the very least.